### PR TITLE
Added 'game type' specific score tracking.

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -212,7 +212,10 @@ export default {
     },
     onGameFinished(){
       this.onExit();
-      Statistics.addScore(this.score);
+      Statistics.addScore(this.score,
+                          this.options.clef,
+                          this.options.difficulty,
+                          this.options.accidentals);
       this.$emit('gameEnded', this.result); 
     },
     quit(){

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -141,17 +141,30 @@ export default {
   watch: {
     "options.language": function(lang) {
       this.$i18n.locale = lang;
+    },
+    "options.clef": function() {
+      this.updateGameType();
+    },
+    "options.difficulty": function() {
+      this.updateGameType();
+    },
+    "options.accidentals": function() {
+      this.updateGameType();
     }
   },
   methods: {
     startGame() {
       Options.saveOptions();
       this.$emit("startGame");
+    },
+    updateGameType() {
+        Statistics.loadStatistics(Options.clef, Options.difficulty, Options.accidentals);
     }
   },
   created() {
     Options.loadOptions();
-    Statistics.loadStatistics();
+    Statistics.init();
+    Statistics.loadStatistics(Options.clef, Options.difficulty, Options.accidentals);
   }
 };
 </script>

--- a/src/components/StatisticsGraph.vue
+++ b/src/components/StatisticsGraph.vue
@@ -6,9 +6,17 @@
 	    :data="chartData"
 	    :options="chartOptions">
 		</chartist>
-		<div>
-			<span class="record">{{$t('record')}}: {{statistics.record}}</span>
-			<button class="reset" @click="resetRecord" v-if="statistics.record > 0">❌</button>
+		<div class="grid-container">
+            <div/>
+            <div>
+                <span class="record">{{$t('record')}}: {{statistics.record}}</span>
+                <button class="reset" @click="resetRecord" v-if="statistics.record > 0">❌</button>
+            </div>
+            <div>
+                <span class="record">{{$t('history')}}: </span>
+                <button class="reset" @click="resetHistory" v-if="statistics.lastScores.length >= 2">❌</button>
+            </div>
+            <div/>
 		</div>
 	</div>
 </template>
@@ -49,6 +57,9 @@ export default {
 	methods: {
 		resetRecord(){
 			Statistics.resetRecord();
+		},
+		resetHistory(){
+			Statistics.resetHistory();
 		}
 	}
 }
@@ -64,5 +75,11 @@ button.reset {
   outline: none;
   cursor: pointer;
   background-color: white;
+}
+
+.grid-container {
+    display: grid;
+    grid-template-columns: 80px auto auto 80px;
+    padding: 5px;
 }
 </style>

--- a/src/model/Statistics.js
+++ b/src/model/Statistics.js
@@ -3,16 +3,56 @@ import * as Lockr from "lockr";
 export default {
   lastScores: [],
   record: 0,
+  clef: [],
+  difficulty: '',
+  accidentals: '',
+  legacyScores: [],
+  legacyRecord: 0,
 
-  loadStatistics() {
-    this.lastScores = Lockr.get("lastScores", []);
-    this.record = Lockr.get("record", 0);
+  init() {
+    this.legacyScores = Lockr.get("lastScores", []);
+    this.legacyRecord = Lockr.get("record", 0);
   },
-  saveStatistics() {
-    Lockr.set("lastScores", this.lastScores);
-    Lockr.set("record", this.record);
+  getScoresKey(clef, difficulty, accidentals) {
+    /* the basic idea is to generate an unique key based on the active user settings.
+     * Only the three types of settings that make a difference in overall game
+     * difficulty/type are considered. */
+    let scoresKey = "lastScores__";
+    return scoresKey.concat(clef.join('_'), '__',  difficulty, '__',  accidentals);
   },
-  addScore(score) {
+  getRecordKey(clef, difficulty, accidentals) {
+    /* the basic idea is to generate an unique key based on the active user settings.
+     * Only the three types of settings that make a difference in overall game
+     * difficulty/type are considered. */
+    let scoresKey = "record__";
+    return scoresKey.concat(clef.join('_'), '__',  difficulty, '__',  accidentals);
+  },
+  loadStatistics(clef, difficulty, accidentals) {
+    // Save arguments for potential later use.
+    this.clef = clef;
+    this.difficulty = difficulty;
+    this.accidentals = accidentals;
+
+    let scoresKey = this.getScoresKey(clef, difficulty, accidentals);
+    let recordKey = this.getRecordKey(clef, difficulty, accidentals);
+
+    /* Use legacy scores and record as a fallback/starting point if the respective
+     * scoresKey has no dedicated entry yet.*/
+    this.lastScores = Lockr.get(scoresKey, this.legacyScores);
+    this.record = Lockr.get(recordKey, this.legacyRecord);
+  },
+  saveStatistics(clef, difficulty, accidentals) {
+    // Save arguments for potential later use.
+    this.clef = clef;
+    this.difficulty = difficulty;
+    this.accidentals = accidentals;
+
+    let scoresKey = this.getScoresKey(clef, difficulty, accidentals);
+    let recordKey = this.getRecordKey(clef, difficulty, accidentals);
+    Lockr.set(scoresKey, this.lastScores);
+    Lockr.set(recordKey, this.record);
+  },
+  addScore(score, clef, difficulty, accidentals) {
     this.lastScores.push(score);
     if (this.lastScores.length > 25) {
       this.lastScores.shift();
@@ -20,10 +60,14 @@ export default {
     if (score > this.record) {
       this.record = score;
     }
-    this.saveStatistics();
+    this.saveStatistics(clef, difficulty, accidentals);
   },
   resetRecord() {
     this.record = 0;
-    this.saveStatistics();
+    this.saveStatistics(this.clef, this.difficulty, this.accidentals);
+  },
+  resetHistory() {
+    this.lastScores = [];
+    this.saveStatistics(this.clef, this.difficulty, this.accidentals);
   }
 };

--- a/src/resources/cz.js
+++ b/src/resources/cz.js
@@ -62,5 +62,6 @@ export default {
   ACCURACY: "PŘESNOST",
   SCORE: "SKǑRE",
 
-  record: "Nejvyšší skóre"
+  record: "Nejvyšší skóre",
+  history: "Dějiny"
 };

--- a/src/resources/de.js
+++ b/src/resources/de.js
@@ -62,5 +62,6 @@ export default {
   ACCURACY: "GENAUIGKEIT",
   SCORE: "PUNKTE",
 
-  record: "Rekord"
+  record: "Rekord",
+  history: "Historie"
 };

--- a/src/resources/en.js
+++ b/src/resources/en.js
@@ -62,5 +62,6 @@ export default {
   ACCURACY: "ACCURACY",
   SCORE: "SCORE",
 
-  record: "High Score"
+  record: "High Score",
+  history: "History"
 };

--- a/src/resources/fr.js
+++ b/src/resources/fr.js
@@ -63,5 +63,6 @@ export default {
   ACCURACY: "PRÉCISION",
   SCORE: "POINTS",
 
-  record: "Record"
+  record: "Record",
+  history: "Histoire"
 };

--- a/src/resources/ln.js
+++ b/src/resources/ln.js
@@ -62,5 +62,6 @@ export default {
   ACCURACY: "POLÉLÉ",
   SCORE: "MONGÉTÉ",
 
-  record: "Elónga"
+  record: "Elónga",
+  history: "History" // TODO: English placeholder, because I couldn't find a translation online.
 };

--- a/src/resources/pl.js
+++ b/src/resources/pl.js
@@ -63,5 +63,6 @@ export default {
   ACCURACY: "POPRAWNOŚĆ",
   SCORE: "PUNKTY",
 
-  record: "Rekord"
+  record: "Rekord",
+  history: "Historia"
 };


### PR DESCRIPTION
Hi again!
Based on https://github.com/MelvilQ/noten-lernen/issues/6, I've created a seemingly functional implementation of what I had in mind back then.

The basic changes are:
- there's no longer a global "lastScores" list or "record"; those two are only used as a fallback so users aren't just loosing any kind of scores they already had
- but in general, every possible combination of clef, difficulty and accidentals now has their own "lastScores" and "record" entries
- when a user sswitched the respective settings, the statistics will update accordingly
- added a button to reset the "lastScores" data of the current "game type", which allows users to "clean up" if they want to

So far I only tested it in browser (so no android build test).
Maybe have a look. I'm open for any kind of feedback if something comes to mind (e.g. functionality, performance, etc.).
