### PR TITLE
Add wrapping of game components for better visibility in landscape mode

### DIFF
--- a/src/components/FeedbackLine.vue
+++ b/src/components/FeedbackLine.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="feedback-line">
-    <span class="feedback correct" v-if="visibleFeedback === 'correct'">{{$t('correctExcl')}}: {{ $t(feedbackNote) }}</span>
+    <span class="feedback correct" v-if="visibleFeedback === 'correct'">{{$t('correctExcl')}} - {{ $t(feedbackNote) }}</span>
     <span class="feedback wrong" v-if="visibleFeedback === 'wrong'">{{$t('wrongExcl')}}</span>
     <span class="feedback dummy" v-if="visibleFeedback === 'none'">dummy</span>
     <span class="feedback dummy" v-if="visibleFeedback === 'none_temp'">dummy_temp</span>

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -1,32 +1,38 @@
 <template>
   <div class="game-screen">
-    <button class="quit" @click="quit">
-      {{$t('ABORT')}}
-    </button>
-    <ScoreLine 
-      :result="result" 
-      :timeLeft="timeLeft"
-      :isInfiniteRound="!options.gameLength" />
-    <NoteDisplay 
-      :currentExercise="currentExercise"
-      @play="playNote(currentExercise.value)" />
-    <FeedbackLine 
-      :feedback="feedback"
-      :feedbackNote="feedbackNote"
-      :uniqueId="numAnswers" />
-    <ButtonInput 
-      v-if="options.inputMode === 'button'" 
-      :isSharp="currentExercise.isSharp" 
-      @solved="checkAnswer" />  
-    <KeyboardInput 
-      v-if="options.inputMode === 'keyboard'" 
-      @solved="checkAnswer" />
-    <MidiInput
-      v-if="options.inputMode === 'midi'"
-      @solved="(value) => checkAnswer(value, true)" />
-    <MousetrapInput 
-      v-if="options.inputMode !== 'midi'"
-      @solved="checkAnswer" />
+    <div class="game-screen-section">
+      <button class="quit" @click="quit">
+        {{$t('ABORT')}}
+      </button>
+      <ScoreLine 
+        :result="result" 
+        :timeLeft="timeLeft"
+        :isInfiniteRound="!options.gameLength" />
+      <FeedbackLine 
+        :feedback="feedback"
+        :feedbackNote="feedbackNote"
+        :uniqueId="numAnswers" />
+    </div>
+    <div class="game-screen-section">
+      <NoteDisplay 
+        :currentExercise="currentExercise"
+        @play="playNote(currentExercise.value)" />
+    </div>
+    <div class="game-screen-section" id="game-screen-input">
+      <ButtonInput 
+        v-if="options.inputMode === 'button'" 
+        :isSharp="currentExercise.isSharp" 
+        @solved="checkAnswer" />  
+      <KeyboardInput 
+        v-if="options.inputMode === 'keyboard'" 
+        @solved="checkAnswer" />
+      <MidiInput
+        v-if="options.inputMode === 'midi'"
+        @solved="(value) => checkAnswer(value, true)" />
+      <MousetrapInput 
+        v-if="options.inputMode !== 'midi'"
+        @solved="checkAnswer" />
+    </div>
   </div>
 </template>
 
@@ -317,9 +323,20 @@ export default {
 .game-screen {
   margin: 0 auto;
   display: flex;
-  justify-content: space-between;
-  flex-direction: column;
+  justify-content: center;
+  flex-flow: row wrap;
   max-width: 720px;
+}
+
+.game-screen-section {
+  display: flex;
+  flex: auto;
+  min-width: 50%;
+  flex-flow: column wrap;
+}
+
+#game-screen-input {
+  min-width: 100%;
 }
 
 button.quit {


### PR DESCRIPTION
Here I'm going for a minimal edit that achieves the goal (fix #24 ). Reorder components so that feedback ("Correct! - G") comes before staff (only so that we can easily get a usable landscape orientation using simple flow).

Change the separator on the feedback line from colon to dash and add space before ("Correct! - G" instead of "Correct!: G").

Attaching screenshots for keyboard input, but looks much the same for button input. With MIDI input, the layout looks a bit empty, but is functional otherwise IMO :)

![Screenshot 2022-09-08 12 17 12](https://user-images.githubusercontent.com/92645652/189208757-e295d492-1d0a-4882-a19b-968637f18919.png)
![Screenshot 2022-09-08 12 16 20](https://user-images.githubusercontent.com/92645652/189208761-55c81f7e-6f84-44f0-ac1f-bea56daddf54.png)
![Screenshot 2022-09-08 12 14 58](https://user-images.githubusercontent.com/92645652/189208764-8e4d5fde-a0b7-47cb-8fd8-e24b49b415f1.png)
