### PR TITLE
Add a "piano" clef to render a bass-treble grand staff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noten-lernen",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "noten-lernen",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "abcjs": "^5.3.5",

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,7 @@ body {
   margin: 0;
   padding: 0;
   user-select: none;
+  height: 100%;
 }
 
 #app {
@@ -46,5 +47,6 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
+  height: 100%;
 }
 </style>

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -13,7 +13,7 @@
         :feedbackNote="feedbackNote"
         :uniqueId="numAnswers" />
     </div>
-    <div class="game-screen-section">
+    <div class="game-screen-section" id="game-note-display">
       <NoteDisplay 
         :currentExercise="currentExercise"
         @play="playNote(currentExercise.value)" />
@@ -67,6 +67,7 @@ export default {
       options: Options,
       currentExercise: {
         clef: 'treble',
+        staff: 'treble',
         value: 36,
         isSharp: false
       },
@@ -238,8 +239,15 @@ export default {
       this.currentExercise = exercise;
     },
     generateExercise(){
-      const clef = _.sample(this.options.clef);
-      const exercise = { clef, value: this.getRandomNoteForClef(clef) };
+      var clef = _.sample(this.options.clef);
+      if(clef === 'piano'){
+        const staves = ['treble', 'bass'];
+        clef = staves[_.random(0, staves.length - 1)];
+        var staff = 'piano';
+      }else{
+        var staff = clef;
+      }
+      const exercise = { clef, staff, value: this.getRandomNoteForClef(clef) };
       switch(this.options.accidentals){
         case 'no':
           exercise.isSharp = true;
@@ -324,8 +332,10 @@ export default {
   margin: 0 auto;
   display: flex;
   justify-content: center;
+  align-items: end;
   flex-flow: row wrap;
   max-width: 720px;
+  height: 100%;
 }
 
 .game-screen-section {
@@ -337,6 +347,25 @@ export default {
 
 #game-screen-input {
   min-width: 100%;
+  align-self: start;
+}
+
+#game-note-display {
+  align-items: center;
+  justify-content: flex-end;
+}
+
+@media (orientation: landscape) {
+  #game-note-display, #game-screen-input {
+    min-height: 50%;
+  }
+}
+
+@media (orientation: portrait) {
+  #game-note-display, #game-screen-input {
+    min-height: 33%;
+    min-width: 100%;
+  }
 }
 
 button.quit {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -117,7 +117,8 @@ export default {
         { value: "treble", label: this.$t("trebleClef") },
         { value: "bass", label: this.$t("bassClef") },
         { value: "alto", label: this.$t("altoClef") },
-        { value: "tenor", label: this.$t("tenorClef") }
+        { value: "tenor", label: this.$t("tenorClef") },
+        { value: "piano", label: this.$t("pianoClef") }
       ];
     },
     difficultyOptions() {

--- a/src/components/NoteDisplay.vue
+++ b/src/components/NoteDisplay.vue
@@ -1,5 +1,7 @@
 <template>
-  <div id="note-display" @click="playCurrentNote"></div>
+  <div id="note-outer-box">
+    <div id="note-display" @click="playCurrentNote"></div>
+  </div>
 </template>
 
 <script>
@@ -60,16 +62,39 @@ export default {
       }
     },
     abc(){
-      return (
-        'L:1/4\nK:C ' + this.currentExercise.clef 
-        + '\n' 
-        + this.accidental + this.note
-      );
+      if (this.currentExercise.staff === 'piano') {
+        return (
+          // Multiple voices notation: https://abcnotation.com/wiki/abc:standard:v2.1#multiple_voices
+          'L:1/4\n'
+          + '%%score {1 2}\n'
+          + 'V:1 clef=treble\n'
+          + 'V:2 clef=bass\n'
+          + 'K:C\n'
+          + '[V:1] ' + (this.currentExercise.clef === 'treble' ? this.accidental + this.note : 'z') + '\n'
+          + '[V:2] ' + (this.currentExercise.clef === 'bass' ? this.accidental + this.note : 'z')
+        )
+      } else {
+        return (
+          'L:1/4\nK:C ' + this.currentExercise.clef
+          + '\n'
+          + this.accidental + this.note
+        );
+      }
     },
   },
   watch: {
-    abc(value){
-      abcjs.renderAbc('note-display', this.abc, {staffwidth: 200, scale: 2.5, clickListener: () => this.unselect()});
+    abc(value) {
+      abcjs.renderAbc('note-display', this.abc, {
+        clickListener: () => this.unselect(),
+        paddingtop: '0',
+        paddingleft: '0',
+        paddingbottom: '0',
+        paddingright: '0',
+        // It is somewhat tricky to size and layout an SVG image correctly. We start by setting 'responsive'
+        // here, which lets us control size via the width of the parent object.
+        responsive: 'resize',
+        staffwidth: 80  // Sufficient to show a single quarter note.
+      });
     }
   },
   methods: {
@@ -88,8 +113,11 @@ export default {
 <style scoped>
 #note-display {
   margin: 0 auto;
-  min-height: 225px;
-  max-height: 225px;
   cursor: pointer;
 }
+
+#note-outer-box {
+  width: 120px;
+}
+
 </style>

--- a/src/resources/cz.js
+++ b/src/resources/cz.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "Basový",
   altoClef: "Altový",
   tenorClef: "Tenorový",
+  pianoClef: "Klávesy",
   easy: "Snadná",
   normal: "Normální",
   hard: "Těžká",

--- a/src/resources/de.js
+++ b/src/resources/de.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "Bass",
   altoClef: "Alt",
   tenorClef: "Tenor",
+  pianoClef: "Klavier",
   easy: "Leicht",
   normal: "Mittel",
   hard: "Schwer",

--- a/src/resources/en.js
+++ b/src/resources/en.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "Bass",
   altoClef: "Alto",
   tenorClef: "Tenor",
+  pianoClef: "Piano",
   easy: "Easy",
   normal: "Normal",
   hard: "Hard",

--- a/src/resources/es.js
+++ b/src/resources/es.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "Fa",
   altoClef: "Alto",
   tenorClef: "Tenor",
+  pianoClef: "Piano",
   easy: "Fácil",
   normal: "Medio",
   hard: "Duro",

--- a/src/resources/fr.js
+++ b/src/resources/fr.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "basse",
   altoClef: "ut (3e)",
   tenorClef: "ut (4e)",
+  pianoClef: "Piano",
   both: "les deux",
   easy: "facile",
   normal: "moyen",

--- a/src/resources/hu.js
+++ b/src/resources/hu.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "Basszus",
   altoClef: "Alt",
   tenorClef: "Tenor",
+  pianoClef: "Zongora",
   easy: "Könnyű",
   normal: "Közepes",
   hard: "Nehéz",

--- a/src/resources/it.js
+++ b/src/resources/it.js
@@ -46,6 +46,7 @@ export default {
     bassClef: "Basso",
     altoClef: "Alto",
     tenorClef: "Tenore",
+    pianoClef: "Pianoforte",
     easy: "Facile",
     normal: "Medio",
     hard: "Difficile",

--- a/src/resources/ja.js
+++ b/src/resources/ja.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "バス",
   altoClef: "アルト",
   tenorClef: "テノール",
+  pianoClef: "ピアノ",
   easy: "易",
   normal: "中",
   hard: "難",

--- a/src/resources/ln.js
+++ b/src/resources/ln.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "bási",
   altoClef: "alto",
   tenorClef: "tenor",
+  pianoClef: "Mángolá",
   easy: "mwa pɛ́tɛ́",
   normal: "mwa katikáti",
   hard: "mwa mpási",

--- a/src/resources/nl.js
+++ b/src/resources/nl.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "Bass",
   altoClef: "Alt",
   tenorClef: "Tenor",
+  pianoClef: "Piano",
   easy: "Makkelijk",
   normal: "Normaal",
   hard: "Moeilijk",

--- a/src/resources/pl.js
+++ b/src/resources/pl.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "basowy",
   altoClef: "altowy",
   tenorClef: "tenorowy",
+  pianoClef: "klawiatura",
   both: "Oba",
   easy: "Łatwy",
   normal: "Normalny",

--- a/src/resources/pt.js
+++ b/src/resources/pt.js
@@ -46,6 +46,7 @@ export default {
   bassClef: "Clave Fá",
   altoClef: "Clave Dó",
   tenorClef: "Tenor",
+  pianoClef: "Piano",
   easy: "Fácil",
   normal: "Normal",
   hard: "Difícil",


### PR DESCRIPTION
CSS changes to better render in portrait, landscape, and large screens.

The clef still jumps around a bit, because the SVG generated by abc.js can vary in height. I chose to keep the note display close to the input rather than adding extra vertical space to avoid jumping (but let me know if you'd rather see different behavior!).

Bump version number in package-lock.json to match (automatically happened when I ran `npm i`).

Attaching a (slow) screen recording, still learning :P

[Screen recording 2022-09-09  #18.51.59.webm](https://user-images.githubusercontent.com/92645652/189464576-fdf4e9ce-85ac-431c-a44f-56d6dc248f94.webm)

Can close #32 with this