### PR TITLE
Persist feedback with low opacity.

### DIFF
--- a/src/components/FeedbackLine.vue
+++ b/src/components/FeedbackLine.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="feedback-line">
-    <span class="feedback correct" v-if="visibleFeedback === 'correct'">{{$t('correctExcl')}} - {{ $t(feedbackNote) }}</span>
+    <span class="feedback correct" v-if="visibleFeedback === 'correct-note'">{{$t('correctExcl')}} - {{ $t(feedbackNote) }}</span>
+    <span class="feedback correct" v-if="visibleFeedback === 'correct'">{{$t('correctExcl')}}</span>
     <span class="feedback wrong" v-if="visibleFeedback === 'wrong'">{{$t('wrongExcl')}}</span>
     <span class="feedback dummy" v-if="visibleFeedback === 'none'">dummy</span>
     <span class="feedback dummy" v-if="visibleFeedback === 'none_temp'">dummy_temp</span>
@@ -43,7 +44,7 @@ export default {
     opacity: 1;
   }
   100% {
-    opacity: 0;
+    opacity: 0.3;
   }
 }
 
@@ -53,7 +54,7 @@ export default {
   color: white;
   border-radius: 5px;
   padding: 1px 5px;
-  opacity: 0;
+  opacity: 0.3;
   animation-name: feedback;
   animation-duration: 0.5s;
   animation-iteration-count: 1;

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -297,10 +297,12 @@ export default {
     },
     onCorrectAnswer(noteValue, isSharp){
       this.numCorrect += 1;
-      this.feedback = 'correct';
 
       if(this.options.displayNote) {
+        this.feedback = 'correct-note';
         this.feedbackNote = Utils.getNoteName(noteValue % 12, isSharp);
+      }else{
+        this.feedback = 'correct';
       }
     },
     onWrongAnswer(wrongValue){


### PR DESCRIPTION
Fix regression where setting "Display correct note" false would show "Correct - None" instead of "Correct".

Persisting feedback should fix #29 

Code staged [here](https://noten-lernen-dev-cm.netlify.app/)