### PR TITLE
Add modal for history deletion

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,0 +1,60 @@
+<template>
+    <div class="modal-overlay">
+        <div class="modal">
+                <div class="modal-title">
+                    {{ title }}
+                </div>
+                <small class="modal-text">
+                    {{ text }}
+                </small>
+            <div class="buttons">
+                <button @click="emitOkAndClose">{{ okButtonText }}</button>
+                <button @click="emitClose">{{ cancelButtonText }}</button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+
+
+export default {
+	name: 'Modal',
+	data(){
+        return  {}
+	},
+    props: {
+        title: String,
+        text: String,
+        okButtonText: String,
+        cancelButtonText: String
+    },
+    methods: {
+        emitClose () {
+            this.$emit("closeModal");
+        },
+        emitOkAndClose() {
+            this.$emit("closeModal");
+            this.$emit("executeAction");
+        }
+    },
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: absolute;
+  left: 25%;
+  right: 25%;
+  background-color: #f0f8ff;
+  top: 25%;
+  border-radius: 15px;
+}
+.modal {
+    padding:20px;
+}
+.buttons {
+    padding:10px;
+}
+
+</style>

--- a/src/components/StatisticsGraph.vue
+++ b/src/components/StatisticsGraph.vue
@@ -9,11 +9,13 @@
 		<div class="grid-container">
             <div>
                 <span class="record">{{$t('record')}}: {{statistics.record}}</span>
-                <button class="reset" @click="resetRecord" v-if="statistics.record > 0">❌</button>
+                <button class="reset" @click="showRecordModal" v-if="statistics.record > 2">❌</button>
+				<modal @executeAction="resetRecord" v-if="showRecordModalProp" @closeModal="showRecordModalProp = false" :title="this.$i18n.t('resetRecordModalHeading')" :text="this.$i18n.t('resetModalText')" :okButtonText="this.$i18n.t('delete')" :cancelButtonText="this.$i18n.t('cancel')"/>
             </div>
             <div>
                 <span class="record">{{$t('history')}}: </span>
                 <button class="reset" @click="resetHistory" v-if="statistics.lastScores.length >= 2">❌</button>
+				<modal @executeAction="resetHistory" v-if="showRecordModalProp" @closeModal="showRecordModalProp = false" :title="this.$i18n.t('resetHistoryModalHeading')" :text="this.$i18n.t('resetModalText')" :okButtonText="this.$i18n.t('delete')" :cancelButtonText="this.$i18n.t('cancel')"/>
             </div>
 		</div>
 	</div>
@@ -24,12 +26,15 @@ import Statistics from '../model/Statistics';
 
 import Chartist from 'chartist';
 import 'chartist/dist/chartist.min.css';
+import Modal from './Modal.vue';
 
 export default {
 	name: 'StatisticsGraph',
+	components: { Modal },
 	data(){
 		return {
-			statistics: Statistics
+			statistics: Statistics,
+			showRecordModalProp: false,
 		}
 	},
 	computed: {
@@ -58,6 +63,9 @@ export default {
 		},
 		resetHistory(){
 			Statistics.resetHistory();
+		},
+		showRecordModal() {
+			this.showRecordModalProp = !this.showRecordModalProp;
 		}
 	}
 }

--- a/src/components/StatisticsGraph.vue
+++ b/src/components/StatisticsGraph.vue
@@ -10,12 +10,12 @@
             <div>
                 <span class="record">{{$t('record')}}: {{statistics.record}}</span>
                 <button class="reset" @click="showRecordModal" v-if="statistics.record > 2">❌</button>
-				<modal @executeAction="resetRecord" v-if="showRecordModalProp" @closeModal="showRecordModalProp = false" :title="this.$i18n.t('resetRecordModalHeading')" :text="this.$i18n.t('resetModalText')" :okButtonText="this.$i18n.t('delete')" :cancelButtonText="this.$i18n.t('cancel')"/>
+				<modal v-if="showRecordModalProp" @executeAction="resetRecord" @closeModal="showRecordModalProp = false" :title="this.$i18n.t('resetRecordModalHeading')" :text="this.$i18n.t('resetModalText')" :okButtonText="this.$i18n.t('delete')" :cancelButtonText="this.$i18n.t('cancel')"/>
             </div>
             <div>
                 <span class="record">{{$t('history')}}: </span>
-                <button class="reset" @click="resetHistory" v-if="statistics.lastScores.length >= 2">❌</button>
-				<modal @executeAction="resetHistory" v-if="showRecordModalProp" @closeModal="showRecordModalProp = false" :title="this.$i18n.t('resetHistoryModalHeading')" :text="this.$i18n.t('resetModalText')" :okButtonText="this.$i18n.t('delete')" :cancelButtonText="this.$i18n.t('cancel')"/>
+                <button class="reset" @click="showHistoryModal" v-if="statistics.lastScores.length >= 2">❌</button>
+				<modal v-if="showHistoryModalProp" @executeAction="resetHistory" @closeModal="showHistoryModalProp = false" :title="this.$i18n.t('resetHistoryModalHeading')" :text="this.$i18n.t('resetModalText')" :okButtonText="this.$i18n.t('delete')" :cancelButtonText="this.$i18n.t('cancel')"/>
             </div>
 		</div>
 	</div>
@@ -35,6 +35,7 @@ export default {
 		return {
 			statistics: Statistics,
 			showRecordModalProp: false,
+			showHistoryModalProp: false
 		}
 	},
 	computed: {
@@ -66,6 +67,9 @@ export default {
 		},
 		showRecordModal() {
 			this.showRecordModalProp = !this.showRecordModalProp;
+		},
+		showHistoryModal() {
+			this.showHistoryModalProp = !this.showHistoryModalProp;
 		}
 	}
 }

--- a/src/resources/de.js
+++ b/src/resources/de.js
@@ -67,9 +67,15 @@ export default {
 
   record: "Rekord",
   history: "Historie",
+  resetRecordModalHeading: "Rekord zurücksetzen",
+  resetHistoryModalHeading: "Historie zurücksetzen",
+  resetModalText: "Hinweis: Die Daten werden endgültig gelöscht.",
 
   noMidiSupport: "Sorry, dein Gerät scheint MIDI nicht zu unterstützen.",
   noDeviceFound: "Kein Gerät gefunden. Bitte das MIDI-Gerät erneut verbinden.",
   playTheNote: "Spiele die Note auf deinem MIDI-Keyboard.",
   lastNotePlayed: "Zuletzt gespielte Note",
+
+  delete: "Löschen",
+  cancel: "Abbrechen",
 };

--- a/src/resources/en.js
+++ b/src/resources/en.js
@@ -67,9 +67,15 @@ export default {
 
   record: "High Score",
   history: "History",
+  resetRecordModalHeading: "Reset high score",
+  resetHistoryModalHeading: "Reset history",
+  resetModalText: "Note: data will be deleted permanently.",
 
   noMidiSupport: "Sorry, it seems as if your device does not support MIDI.",
   noDeviceFound: "No device found. Please reconnect the MIDI device.",
   playTheNote: "Play the note on your MIDI keyboard.",
   lastNotePlayed: "Last note played",
+
+  delete: "Delete",
+  cancel: "Cancel",
 };


### PR DESCRIPTION
This PR integrates two basic modals, in which the user has to confirm the deletion of high score and history. The modals are based on a generic modal, that can be used in other parts of the app as well.

The modals offer 4 properties:

- title: for the title of the modal,
- text: for the "body" of the modal,
- okButtonText: text for the first button,
- cancelButtonText: text for the second button.

Clicking on the ok-Button emits the event "closeModal" and "executeAction". Parent components can subscribe on these events and act accordingly. This also applies for the two modals asking for confirmation of deletion of data.

I issued this PR, since I accidentially hit the "delete button" and lost my incredibly high high-score :) Deleting data should always be confirmed, which would be added through this PR.