### PR TITLE
Make selection of multiple clefs independent of the order they were selected in

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -25,7 +25,8 @@
         <SelectOptionMulti 
           :label="$t('CLEF')"
           :items="clefOptions"
-          v-model="options.clef"
+          v-bind:value="options.clef"
+          v-on:input="options.clef = $event.sort()"
         />
       </div>
       <div class="setting">


### PR DESCRIPTION
This PR makes selections of clefs independent of the order they were selected in. So if "Treble" is selected and "Bass" is clicked and added, it will show the same statistics and count as the same game type as if "Bass" is selected and "Treble" is clicked and added.

This is an extremely simple fix, but it does not account for old instances or installations of the web site / app; if someone updates and has statistics for eg. ["Treble", "Bass"], these will be lost.

closes #44 